### PR TITLE
Add CSV ingestion script (follow-up: surface row mapping failures)

### DIFF
--- a/ingestion.gs
+++ b/ingestion.gs
@@ -66,6 +66,14 @@ function processSingleCSVFile_(file, existingKeysSet) {
     appendRecords_(deduped);
     deduped.forEach(r => existingKeysSet.add(buildKey_(r)));
 
+    if (mapped.errors.length) {
+      return {
+        ok: false,
+        rowsAppended: deduped.length,
+        reason: `${mapped.errors.length} row(s) failed to map; CSV retained in RAW`
+      };
+    }
+
     return { ok: true, rowsAppended: deduped.length, reason: '' };
   } catch (e) {
     alert_(`[CSV Import] Exception for "${file.getName()}"`, stringifyError_(e));


### PR DESCRIPTION
## Summary
- add a Google Apps Script file that ingests CSV files from Drive into the transactions sheet
- include helpers for mapping, deduplication, and archiving to support ingestion
- surface row mapping failures so partially ingested CSVs remain in RAW for review

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f54879e814832b9b5f1b2f4acd874a