### PR TITLE
Add safe alert fallbacks when alerting utilities missing

### DIFF
--- a/config.gs
+++ b/config.gs
@@ -136,3 +136,33 @@ function escapeHtml_(s) {
     .replace(/&/g, '&amp;').replace(/</g, '&lt;')
     .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
+
+/**
+ * Helper wrappers that gracefully fall back to console logging when the
+ * optional alerting utilities are not loaded in the Apps Script project.
+ */
+function notifyAlert_(subject, body) {
+  if (typeof alert_ === 'function') {
+    try {
+      alert_(subject, body);
+      return;
+    } catch (err) {
+      console.error('[Alert fallback] Failed to send alert via alert_');
+      console.error(stringifyError_(err));
+    }
+  }
+  console.log(`[ALERT] ${subject}\n${body}`);
+}
+
+function notifyInfo_(msg) {
+  if (typeof logInfo_ === 'function') {
+    try {
+      logInfo_(msg);
+      return;
+    } catch (err) {
+      console.error('[Log fallback] Failed to log via logInfo_');
+      console.error(stringifyError_(err));
+    }
+  }
+  console.log(msg);
+}

--- a/ingestion.gs
+++ b/ingestion.gs
@@ -29,15 +29,15 @@ function ingestAllCSVs() {
     }
 
     if (problems.length) {
-      alert_('[CSV Import] Some files could not be mapped', problems.join('\n'));
+      notifyAlert_('[CSV Import] Some files could not be mapped', problems.join('\n'));
     }
     if (processed.length) {
-      logInfo_('[CSV Import] Done:\n' + processed.map(n => `• ${n}: ${counts[n]} new rows`).join('\n'));
+      notifyInfo_('[CSV Import] Done:\n' + processed.map(n => `• ${n}: ${counts[n]} new rows`).join('\n'));
     } else {
-      logInfo_('[CSV Import] No CSVs found.');
+      notifyInfo_('[CSV Import] No CSVs found.');
     }
   } catch (e) {
-    alert_('[CSV Import] Fatal error', stringifyError_(e));
+    notifyAlert_('[CSV Import] Fatal error', stringifyError_(e));
     throw e;
   }
 }
@@ -59,7 +59,7 @@ function processSingleCSVFile_(file, existingKeysSet) {
 
     const mapped = mapCsvRowsToTarget_(rows, header, cfg, file.getName());
     if (mapped.errors.length) {
-      alert_(`[CSV Import] Row mapping issues in ${file.getName()}`, mapped.errors.slice(0, 30).join('\n'));
+      notifyAlert_(`[CSV Import] Row mapping issues in ${file.getName()}`, mapped.errors.slice(0, 30).join('\n'));
     }
 
     const deduped = mapped.records.filter(r => !existingKeysSet.has(buildKey_(r)));
@@ -68,7 +68,7 @@ function processSingleCSVFile_(file, existingKeysSet) {
 
     return { ok: true, rowsAppended: deduped.length, reason: '' };
   } catch (e) {
-    alert_(`[CSV Import] Exception for "${file.getName()}"`, stringifyError_(e));
+    notifyAlert_(`[CSV Import] Exception for "${file.getName()}"`, stringifyError_(e));
     return { ok: false, rowsAppended: 0, reason: 'Exception thrown; see alert' };
   }
 }
@@ -269,7 +269,7 @@ function moveToArchiveIfConfigured_(file) {
     const parents = file.getParents();
     if (parents.hasNext()) parents.next().removeFile(file);
   } catch (e) {
-    alert_('[CSV Import] Failed to archive file', `${file.getName()}\n\n${stringifyError_(e)}`);
+    notifyAlert_('[CSV Import] Failed to archive file', `${file.getName()}\n\n${stringifyError_(e)}`);
   }
 }
 

--- a/rules.gs
+++ b/rules.gs
@@ -17,7 +17,7 @@ function onEdit(e) {
       categorizeTransactions();
     }
   } catch (err) {
-    alert_('[Rules] onEdit error', stringifyError_(err));
+    notifyAlert_('[Rules] onEdit error', stringifyError_(err));
   }
 }
 
@@ -36,7 +36,7 @@ function categorizeTransactions() {
     const rules = readRules_();
     applyRulesToMain_(rules);
   } catch (e) {
-    alert_('[Rules] categorizeTransactions error', stringifyError_(e));
+    notifyAlert_('[Rules] categorizeTransactions error', stringifyError_(e));
     throw e;
   }
 }


### PR DESCRIPTION
## Summary
- add helper wrappers that fall back to console logging when alerting utilities are not present
- update ingestion and rule scripts to use the wrappers so missing alerting module no longer throws

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f568a954ac832b89e2d5f78190380c