### PR TITLE
Add pull request test workflow and contributor guidance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ PY path/to/sample.csv
 - Run `categorizeTransactions()` to reapply your rules. The simple `onEdit(e)` trigger will call it automatically when you edit the `Rules` tab or new transactions arrive.
 - Call `installTriggers()` from `rules.gs` if you want time-based triggers that ingest and categorize hourly.
 
+## Testing
+- Continuous integration runs `npm test` on every pull request. If you change ingestion or rules logic, add or update the corresponding tests so the workflow stays green.
+- Locally, install dependencies with `npm ci` and run `npm test` before opening a pull request.
+
 ## Maintenance tips
 - If ingestion fails, check the execution log and the alert email for the stack trace provided by `alerting.gs`.
 - When you update the target schema, update both the sheet header row and every mapping in `CONFIGS_BY_HEADER_HASH` to include the new columns.


### PR DESCRIPTION
## Summary
- add a pull-request GitHub Actions workflow that installs dependencies with caching and runs `npm test`
- document how to run the test suite locally so contributors keep ingestion and rules coverage current

## Testing
- not run (CI only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a968ddb4832b8e9b59232a68a9d8)