### PR TITLE
Normalize date keys during ingestion dedupe

### DIFF
--- a/ingestion.gs
+++ b/ingestion.gs
@@ -209,13 +209,20 @@ function normalizeMonetaryFields_(rec, cfg) {
 }
 
 function buildKey_(rec) {
-  const date = rec.date;
+  const date = normalizeDateForKey_(rec.date);
   const deposit = Number(rec.deposit || 0).toFixed(2);
   const withdrawal = Number(rec.withdrawal || 0).toFixed(2);
   const desc = (rec.description || '').toLowerCase().replace(/\s+/g, ' ').trim();
   const acct = (rec.account_name || '').toLowerCase().trim();
   const type = (rec.type || '').toLowerCase().trim();
   return [date, withdrawal, deposit, desc, acct, type].join(' | ');
+}
+
+function normalizeDateForKey_(value) {
+  if (value instanceof Date && !isNaN(value.getTime())) {
+    return formatISODate_(value);
+  }
+  return String(value || '').trim();
 }
 
 function buildExistingKeySet_(sheet) {


### PR DESCRIPTION
### Motivation
- Duplicate detection could miss matches when existing ledger rows store `date` as a `Date` object while new records use ISO strings, producing different keys.
- The goal is to make key generation consistent so identical transactions with semantically equal dates dedupe correctly.
- Reuse the existing ISO formatting to keep keys stable and human-readable.

### Description
- Updated `buildKey_` in `ingestion.gs` to call a new helper `normalizeDateForKey_` for the `date` component.
- Added `normalizeDateForKey_` which converts `Date` objects to ISO via `formatISODate_` and otherwise coerces dates to trimmed strings.
- No other key components or mapping logic were changed.

### Testing
- No automated tests were run for this change.
- Manual testing recommended by ingesting a small CSV with overlapping rows after applying the patch to confirm duplicates are suppressed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bca577b78832b82d2696ed9509f37)