### PR TITLE
Introduce modular src/ structure for ingestion, categorization, sheets, and alerts

### DIFF
--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -1,0 +1,40 @@
+import { CFG } from './config';
+
+export function getRequiredProperty(name) {
+  if (CFG && Object.prototype.hasOwnProperty.call(CFG, name) && CFG[name]) {
+    return CFG[name];
+  }
+  if (typeof PropertiesService !== 'undefined') {
+    const value = PropertiesService.getScriptProperties().getProperty(name);
+    if (value) return value;
+  }
+  throw new Error(`Missing required property: ${name}`);
+}
+
+export function getAlertEmail() {
+  return getRequiredProperty('ALERT_EMAIL');
+}
+
+export function sendAlert(subject, body) {
+  try {
+    MailApp.sendEmail({
+      to: getAlertEmail(),
+      subject,
+      htmlBody: `<pre>${escapeHtml(body)}</pre>`
+    });
+  } catch (error) {
+    console.error('ALERT FAILED\n' + subject + '\n' + body + '\n' + stringifyError(error));
+  }
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function stringifyError(error) {
+  if (!error) return 'Unknown error';
+  const message = error.message ? error.message : (error.toString ? error.toString() : String(error));
+  return message + (error.stack ? `\n\n${error.stack}` : '');
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,2 @@
+export { ingestCSVs } from './ingestion';
+export { applyCategorization, onEdit } from './categorization';

--- a/src/categorization.ts
+++ b/src/categorization.ts
@@ -1,0 +1,155 @@
+import { CFG } from './config';
+import { normalizeHeader, notifyAlert, stringifyError } from './core';
+import { ensureColumn, ensureSheetWithHeaders, createHeaderIndex, rowToRecord } from './sheets';
+
+export function onEdit(e) {
+  try {
+    const sheet = e && e.range && e.range.getSheet();
+    if (!sheet) return;
+    const name = sheet.getName();
+    if (name === CFG.RULES_SHEET_NAME || (name === CFG.TARGET_SHEET_NAME && e.range.getRow() > 1)) {
+      applyCategorization();
+    }
+  } catch (error) {
+    notifyAlert('[Rules] onEdit error', stringifyError(error));
+  }
+}
+
+export function applyCategorization() {
+  try {
+    const rules = loadRules();
+    applyRulesToMain(rules);
+  } catch (error) {
+    notifyAlert('[Rules] applyCategorization error', stringifyError(error));
+    throw error;
+  }
+}
+
+export function loadRules() {
+  const sheet = ensureSheetWithHeaders(CFG.RULES_SHEET_NAME, []);
+  const values = sheet.getDataRange().getValues();
+  if (values.length <= 1) return [];
+  const header = values[0].map(h => String(h).trim());
+  const index = createHeaderIndex(header);
+  const columns = [
+    ['id', 'Rule ID'],
+    ['status', 'Status'],
+    ['descriptionRegex', 'Description Regex'],
+    ['typeRegex', 'Type Regex'],
+    ['categoryRegex', 'Category Regex'],
+    ['accountNameRegex', 'AccountName Regex'],
+    ['minAmt', 'Min Amount'],
+    ['maxAmt', 'Max Amount'],
+    ['category', 'Category Assigned by Rule']
+  ];
+
+  const missing = [];
+  const resolved = {};
+  columns.forEach(([key, label]) => {
+    const idx = index[normalizeHeader(label)];
+    if (idx === undefined) {
+      missing.push(label);
+    }
+    resolved[key] = idx;
+  });
+
+  if (missing.length) {
+    throw new Error('Rules sheet missing required column(s): ' + missing.join(', '));
+  }
+
+  const list = [];
+  for (let i = 1; i < values.length; i++) {
+    const row = values[i];
+    if (row.every(c => String(c).trim() === '')) continue;
+    const status = String(row[resolved.status] || '').trim().toUpperCase();
+    if (status !== 'ON') continue;
+    const categoryCell = String(row[resolved.category] || '').trim();
+    if (!categoryCell) continue;
+    const minStr = String(row[resolved.minAmt] ?? '').trim();
+    const maxStr = String(row[resolved.maxAmt] ?? '').trim();
+    const ruleId = String(row[resolved.id] || '').trim();
+
+    const descriptionPattern = String(row[resolved.descriptionRegex] || '').trim();
+    const typePattern = String(row[resolved.typeRegex] || '').trim();
+    const categoryPattern = String(row[resolved.categoryRegex] || '').trim();
+    const accountNamePattern = String(row[resolved.accountNameRegex] || '').trim();
+
+    list.push({
+      id: ruleId,
+      descriptionRegex: compileRuleRegex(descriptionPattern, 'Description Regex', ruleId),
+      typeRegex: compileRuleRegex(typePattern, 'Type Regex', ruleId),
+      categoryRegex: compileRuleRegex(categoryPattern, 'Category Regex', ruleId),
+      accountNameRegex: compileRuleRegex(accountNamePattern, 'AccountName Regex', ruleId),
+      minAmount: minStr === '' ? null : parseFloat(minStr),
+      maxAmount: maxStr === '' ? null : parseFloat(maxStr),
+      category: categoryCell
+    });
+  }
+
+  return list;
+}
+
+function compileRuleRegex(pattern, label, ruleId) {
+  if (!pattern) return null;
+  try {
+    return new RegExp(pattern, 'i');
+  } catch (error) {
+    const idText = ruleId ? ` (Rule ID: ${ruleId})` : '';
+    throw new Error(`Invalid ${label}${idText}: ${error.message}`);
+  }
+}
+
+function applyRulesToMain(rules) {
+  const sheet = ensureSheetWithHeaders(CFG.TARGET_SHEET_NAME, CFG.TARGET_SCHEMA);
+  const values = sheet.getDataRange().getValues();
+  if (values.length <= 1) return;
+
+  const header = values[0];
+  const index = createHeaderIndex(header);
+
+  const catAuditIndex = ensureColumn(sheet, header, 'Category by Rule');
+  const ruleAuditIndex = ensureColumn(sheet, header, 'Matched Rule ID');
+
+  const dataRows = values.slice(1);
+  const outCat = [];
+  const outRule = [];
+
+  for (let r = 0; r < dataRows.length; r++) {
+    const row = dataRows[r];
+    const record = rowToRecord(row, header);
+    const description = String(record.description || '');
+    const txnType = index.type === undefined ? '' : String(record.type || '');
+    const txnCategory = index.category === undefined ? '' : String(record.category || '');
+    const accountName = index.account_name === undefined ? '' : String(record.account_name || '');
+    const withdrawal = index.withdrawal === undefined ? 0 : Number(record.withdrawal || 0);
+    const deposit = index.deposit === undefined ? 0 : Number(record.deposit || 0);
+    const signedAmount = deposit - withdrawal;
+    const magnitude = Math.abs(signedAmount);
+
+    let matched = null;
+    for (const rule of rules) {
+      if (rule.descriptionRegex && !rule.descriptionRegex.test(description)) continue;
+      if (rule.typeRegex && !rule.typeRegex.test(txnType)) continue;
+      if (rule.categoryRegex && !rule.categoryRegex.test(txnCategory)) continue;
+      if (rule.accountNameRegex && !rule.accountNameRegex.test(accountName)) continue;
+      if (rule.minAmount != null && magnitude < rule.minAmount) continue;
+      if (rule.maxAmount != null && magnitude > rule.maxAmount) continue;
+
+      matched = rule;
+      break;
+    }
+
+    if (matched) {
+      outCat.push(matched.category);
+      outRule.push(matched.id);
+    } else {
+      outCat.push('');
+      outRule.push('');
+    }
+  }
+
+  if (dataRows.length > 0) {
+    sheet.getRange(2, catAuditIndex + 1, dataRows.length, 1).setValues(outCat.map(x => [x]));
+    sheet.getRange(2, ruleAuditIndex + 1, dataRows.length, 1).setValues(outRule.map(x => [x]));
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,72 @@
+export const CFG = {
+  // --- Folders ---
+  RAW_FOLDER_ID: 'PUT_RAW_FOLDER_ID_HERE',
+  ARCHIVE_FOLDER_ID: 'PUT_ARCHIVE_FOLDER_ID_HERE', // '' to skip archiving
+
+  // --- Tabs / Sheet names ---
+  TARGET_SHEET_NAME: 'Transactions',
+  RULES_SHEET_NAME: 'Rules',
+
+  // --- Alerts ---
+  ALERT_EMAIL: 'you@example.com',
+
+  // --- Duplicate handling ---
+  DUPLICATE_TRANSACTION_AT_INGESTION_PREFIX: '[Possible Duplicate] ',
+
+  // --- Unified schema for the Transactions sheet (header row) ---
+  TARGET_SCHEMA: [
+    'account_name',
+    'financial_institution',
+    'date',
+    'type',
+    'description',
+    'withdrawal',
+    'deposit',
+    'check_number',
+    'category',
+    'source_file'
+  ],
+
+  // --- Default time zone for any date parsing that needs it ---
+  TIMEZONE: 'America/Los_Angeles'
+};
+
+export const CONFIGS_BY_HEADER_HASH = {
+  // --- EXAMPLES: replace the hashes and headers with your real ones ---
+
+  // Chase example
+  'sha256:b8d252a0bea5609a9ed14d51ae0a214a556c2b949626d1b27c2cfc538544d238': {
+    accountName: 'Chase',
+    financialInstitutionName: 'Chase Bank',
+    dateFormats: ['MM/dd/yyyy'],
+    signConvention: 'expenses_negative',
+    mapping: {
+      // 'Details' - this is just 'DEBIT' or 'CREDIT', embedded in the sign of the Amount
+      'Posting Date': 'date',
+      'Description': 'description',
+      'Amount': 'deposit',
+      'Type': 'type',
+      // 'Balance'
+      'Check or Slip #': 'check_number',
+      'Check or Slip # ': 'check_number'
+    }
+  },
+
+  // Charles Schwab example
+  'sha256:0741502d4e8f7779dc44e8e3b0434bbbd71c57edce8b7fa5c69d9db1ef5d6199': {
+    accountName: 'CharlesSchwab',
+    financialInstitutionName: 'Charles Schwab Bank',
+    dateFormats: ['MM/dd/yyyy'],
+    signConvention: 'raw_sign',
+    mapping: {
+      'Date': 'date',
+      // 'Status': , posted/pending
+      'Type': 'type',
+      'CheckNumber': 'check_number',
+      'Description': 'description',
+      'Withdrawal': 'withdrawal',
+      'Deposit': 'deposit'
+      // 'RunningBalance'
+    }
+  }
+};

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,52 @@
+import { sendAlert } from './alerts';
+import { CFG } from './config';
+
+export function getTargetSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(CFG.TARGET_SHEET_NAME);
+  if (!sheet) sheet = ss.insertSheet(CFG.TARGET_SHEET_NAME);
+  return sheet;
+}
+
+export function getRulesSheet() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(CFG.RULES_SHEET_NAME);
+  if (!sheet) sheet = ss.insertSheet(CFG.RULES_SHEET_NAME);
+  return sheet;
+}
+
+export function normalizeHeader(value) {
+  return String(value).toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+export function bytesToHex(bytes) {
+  return bytes.map(b => (b + 256 & 255).toString(16).padStart(2, '0')).join('');
+}
+
+export function formatISODate(dateValue) {
+  const year = dateValue.getFullYear();
+  const month = String(dateValue.getMonth() + 1).padStart(2, '0');
+  const day = String(dateValue.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function stringifyError(error) {
+  if (!error) return 'Unknown error';
+  const message = error.message ? error.message : (error.toString ? error.toString() : String(error));
+  return message + (error.stack ? `\n\n${error.stack}` : '');
+}
+
+export function notifyAlert(subject, body) {
+  try {
+    sendAlert(subject, body);
+    return;
+  } catch (err) {
+    console.error('[Alert fallback] Failed to send alert');
+    console.error(stringifyError(err));
+  }
+  console.log(`[ALERT] ${subject}\n${body}`);
+}
+
+export function notifyInfo(message) {
+  console.log(message);
+}

--- a/src/ingestion.ts
+++ b/src/ingestion.ts
@@ -1,0 +1,246 @@
+import { CFG, CONFIGS_BY_HEADER_HASH } from './config';
+import { bytesToHex, formatISODate, normalizeHeader, notifyAlert, notifyInfo, stringifyError } from './core';
+import { buildExistingKeys, createHeaderIndex, ensureSheetWithHeaders } from './sheets';
+
+export function ingestCSVs() {
+  try {
+    const sheet = ensureSheetWithHeaders(CFG.TARGET_SHEET_NAME, CFG.TARGET_SCHEMA);
+    const folder = DriveApp.getFolderById(CFG.RAW_FOLDER_ID);
+    const files = folder.getFilesByType(MimeType.CSV);
+    const existingKeys = buildExistingKeys(sheet, buildKey);
+
+    const processed = [];
+    const problems = [];
+    const counts = {};
+
+    while (files.hasNext()) {
+      const file = files.next();
+      const res = processSingleCSVFile(file, existingKeys);
+      if (res.ok) {
+        processed.push(file.getName());
+        counts[file.getName()] = res.rowsAppended;
+        archiveFileIfConfigured(file);
+      } else {
+        problems.push(`${file.getName()} → ${res.reason}`);
+      }
+    }
+
+    if (problems.length) {
+      notifyAlert('[CSV Import] Some files could not be mapped', problems.join('\n'));
+    }
+    if (processed.length) {
+      notifyInfo('[CSV Import] Done:\n' + processed.map(n => `• ${n}: ${counts[n]} new rows`).join('\n'));
+    } else {
+      notifyInfo('[CSV Import] No CSVs found.');
+    }
+  } catch (error) {
+    notifyAlert('[CSV Import] Fatal error', stringifyError(error));
+    throw error;
+  }
+}
+
+export function computeHeaderHash(headerRow) {
+  const normalized = headerRow.map(header => normalizeHeader(header)).join('|');
+  const digest = Utilities.computeDigest(Utilities.DigestAlgorithm.SHA_256, normalized);
+  return `sha256:${bytesToHex(digest)}`;
+}
+
+export function mapRowToRecord(rawRow, headerIndex, cfg, sourceFileName, seenWithinCsv) {
+  const record = emptyTargetRecord();
+  record.source_file = sourceFileName;
+
+  for (const [srcHeader, targetField] of Object.entries(cfg.mapping)) {
+    const idx = headerIndex[normalizeHeader(srcHeader)];
+    if (idx == null) continue;
+    record[targetField] = String(rawRow[idx]).trim();
+  }
+
+  record.date = parseDateFlexible(record.date, cfg.dateFormats);
+  normalizeMonetaryFields(record, cfg);
+
+  record.description = record.description || '';
+  record.account_name = record.account_name || (cfg.accountName || '');
+  record.financial_institution = record.financial_institution || (cfg.financialInstitutionName || '');
+  record.type = record.type || '';
+  record.check_number = record.check_number || '';
+  record.category = record.category || '';
+
+  const baseKey = buildKey(record);
+  if (seenWithinCsv.has(baseKey)) {
+    const prefix = CFG.DUPLICATE_TRANSACTION_AT_INGESTION_PREFIX || '[Possible Duplicate] ';
+    record.description = prefix + record.description;
+  } else {
+    seenWithinCsv.add(baseKey);
+  }
+
+  return record;
+}
+
+export function buildRowFromRecord(record) {
+  return CFG.TARGET_SCHEMA.map(col => record[col] ?? '');
+}
+
+export function archiveFileIfConfigured(file) {
+  if (!CFG.ARCHIVE_FOLDER_ID) return;
+  try {
+    const archive = DriveApp.getFolderById(CFG.ARCHIVE_FOLDER_ID);
+    archive.addFile(file);
+    const parents = file.getParents();
+    if (parents.hasNext()) parents.next().removeFile(file);
+  } catch (error) {
+    notifyAlert('[CSV Import] Failed to archive file', `${file.getName()}\n\n${stringifyError(error)}`);
+  }
+}
+
+function processSingleCSVFile(file, existingKeysSet) {
+  try {
+    const text = file.getBlob().getDataAsString('UTF-8');
+    const rows = Utilities.parseCsv(text);
+    if (!rows || rows.length === 0) {
+      return { ok: false, rowsAppended: 0, reason: 'Empty or unreadable CSV' };
+    }
+
+    const header = rows[0].map(s => String(s).trim());
+    const hash = computeHeaderHash(header);
+    const cfg = CONFIGS_BY_HEADER_HASH[hash];
+    if (!cfg) {
+      return { ok: false, rowsAppended: 0, reason: `Unknown header hash: ${hash}\nHeader: [${header.join(' | ')}]` };
+    }
+
+    const mapped = mapCsvRowsToTarget(rows, header, cfg, file.getName());
+    if (mapped.errors.length) {
+      notifyAlert(`[CSV Import] Row mapping issues in ${file.getName()}`, mapped.errors.slice(0, 30).join('\n'));
+    }
+
+    const deduped = mapped.records.filter(r => !existingKeysSet.has(buildKey(r)));
+    appendRecords(deduped);
+    deduped.forEach(r => existingKeysSet.add(buildKey(r)));
+
+    return { ok: true, rowsAppended: deduped.length, reason: '' };
+  } catch (error) {
+    notifyAlert(`[CSV Import] Exception for "${file.getName()}"`, stringifyError(error));
+    return { ok: false, rowsAppended: 0, reason: 'Exception thrown; see alert' };
+  }
+}
+
+function mapCsvRowsToTarget(rows, header, cfg, sourceFileName) {
+  const headerIndex = createHeaderIndex(header);
+  const records = [];
+  const errors = [];
+  const seenWithinCsv = new Set();
+
+  for (let r = 1; r < rows.length; r++) {
+    const raw = rows[r];
+    if (raw.every(cell => String(cell).trim() === '')) continue;
+
+    try {
+      const record = mapRowToRecord(raw, headerIndex, cfg, sourceFileName, seenWithinCsv);
+      records.push(record);
+    } catch (rowError) {
+      errors.push(`Row ${r + 1}: ${stringifyError(rowError)}`);
+    }
+  }
+
+  return { records, errors };
+}
+
+function emptyTargetRecord() {
+  const obj = {};
+  CFG.TARGET_SCHEMA.forEach(k => {
+    obj[k] = '';
+  });
+  return obj;
+}
+
+function parseDateFlexible(value, formats) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  for (const fmt of (formats || [])) {
+    const parsed = tryParseDate(raw, fmt);
+    if (parsed) return formatISODate(parsed);
+  }
+  const fallback = new Date(raw);
+  if (!isNaN(fallback.getTime())) return formatISODate(fallback);
+  throw new Error(`Unparseable date "${raw}"`);
+}
+
+function tryParseDate(text, pattern) {
+  try {
+    return Utilities.parseDate(text, CFG.TIMEZONE, pattern);
+  } catch (error) {
+    return null;
+  }
+}
+
+function normalizeAmount(value, signConvention) {
+  let s = String(value || '').replace(/[$,]/g, '').trim();
+  if (s === '') return 0;
+  const parenNeg = /^\((.*)\)$/.test(s);
+  if (parenNeg) s = s.replace(/^\(|\)$/g, '');
+  let n = Number(s);
+  if (isNaN(n)) throw new Error(`Unparseable amount "${value}"`);
+  if (parenNeg) n = -Math.abs(n);
+  if (signConvention === 'expenses_negative') return n;
+  return n;
+}
+
+function normalizeMonetaryFields(record, cfg) {
+  const hasWithdrawal = String(record.withdrawal || '').trim() !== '';
+  const hasDeposit = String(record.deposit || '').trim() !== '';
+  if (hasWithdrawal) {
+    const withdrawal = Math.abs(normalizeAmount(record.withdrawal, 'raw_sign'));
+    record.withdrawal = withdrawal === 0 ? '' : withdrawal;
+  } else {
+    record.withdrawal = '';
+  }
+
+  if (hasDeposit) {
+    const deposit = Math.abs(normalizeAmount(record.deposit, 'raw_sign'));
+    record.deposit = deposit === 0 ? '' : deposit;
+  } else {
+    record.deposit = '';
+  }
+
+  const amountSource = String(record.amount || '').trim();
+  if (!hasWithdrawal && !hasDeposit && amountSource !== '') {
+    const amount = normalizeAmount(amountSource, cfg.signConvention);
+    if (amount < 0) {
+      const value = Math.abs(amount);
+      record.withdrawal = value === 0 ? '' : value;
+      record.deposit = '';
+    } else if (amount > 0) {
+      const value = Math.abs(amount);
+      record.deposit = value === 0 ? '' : value;
+      record.withdrawal = '';
+    } else {
+      record.withdrawal = '';
+      record.deposit = '';
+    }
+  }
+
+  delete record.amount;
+}
+
+function buildKey(record) {
+  const date = normalizeDateForKey(record.date);
+  const deposit = Number(record.deposit || 0).toFixed(2);
+  const withdrawal = Number(record.withdrawal || 0).toFixed(2);
+  const desc = (record.description || '').toLowerCase().replace(/\s+/g, ' ').trim();
+  const acct = (record.account_name || '').toLowerCase().trim();
+  const type = (record.type || '').toLowerCase().trim();
+  return [date, withdrawal, deposit, desc, acct, type].join(' | ');
+}
+
+function normalizeDateForKey(value) {
+  if (value instanceof Date && !isNaN(value.getTime())) {
+    return formatISODate(value);
+  }
+  return String(value || '').trim();
+}
+
+function appendRecords(records) {
+  if (!records || records.length === 0) return;
+  const sheet = ensureSheetWithHeaders(CFG.TARGET_SHEET_NAME, CFG.TARGET_SCHEMA);
+  const rows = records.map(buildRowFromRecord);
+  sheet.getRange(sheet.getLastRow() + 1, 1, rows.length, CFG.TARGET_SCHEMA.length).setValues(rows);
+}

--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -1,0 +1,80 @@
+import { normalizeHeader } from './core';
+
+export function ensureSheetWithHeaders(sheetName, headers) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName(sheetName);
+  if (!sheet) sheet = ss.insertSheet(sheetName);
+  if (headers && headers.length) {
+    ensureHeaders(sheet, headers);
+  }
+  return sheet;
+}
+
+export function ensureHeaders(sheet, headers) {
+  const existingRow = sheet.getLastRow() > 0
+    ? sheet.getRange(1, 1, 1, Math.max(sheet.getLastColumn(), headers.length)).getValues()[0]
+    : [];
+  if (existingRow.length === 0) {
+    sheet.getRange(1, 1, 1, headers.length).setValues([headers]);
+    return headers.slice();
+  }
+  const headerRow = existingRow.slice();
+  headers.forEach(header => {
+    ensureColumn(sheet, headerRow, header);
+  });
+  return headerRow;
+}
+
+export function ensureColumn(sheet, headerRow, columnName) {
+  let idx = headerRow.indexOf(columnName);
+  if (idx === -1) {
+    headerRow.push(columnName);
+    sheet.getRange(1, 1, 1, headerRow.length).setValues([headerRow]);
+    idx = headerRow.length - 1;
+  }
+  return idx;
+}
+
+export function createHeaderIndex(headerRow) {
+  const index = {};
+  headerRow.forEach((header, i) => {
+    index[normalizeHeader(header)] = i;
+  });
+  return index;
+}
+
+export function rowToRecord(row, headerRow) {
+  const record = {};
+  headerRow.forEach((header, i) => {
+    record[normalizeHeader(header)] = row[i];
+  });
+  return record;
+}
+
+export function buildExistingKeys(sheet, buildKey) {
+  const values = safeGetValues(sheet);
+  if (values.length <= 1) return new Set();
+  const header = values[0];
+  const headerIndex = createHeaderIndex(header);
+  const set = new Set();
+  for (let i = 1; i < values.length; i++) {
+    const row = values[i];
+    const record = {
+      date: headerIndex.date === undefined ? '' : row[headerIndex.date],
+      withdrawal: headerIndex.withdrawal === undefined ? '' : row[headerIndex.withdrawal],
+      deposit: headerIndex.deposit === undefined ? '' : row[headerIndex.deposit],
+      description: headerIndex.description === undefined ? '' : row[headerIndex.description],
+      account_name: headerIndex.account_name === undefined ? '' : row[headerIndex.account_name],
+      type: headerIndex.type === undefined ? '' : row[headerIndex.type]
+    };
+    set.add(buildKey(record));
+  }
+  return set;
+}
+
+function safeGetValues(sheet) {
+  const lastRow = sheet.getLastRow();
+  const lastCol = sheet.getLastColumn();
+  if (lastRow === 0) return [];
+  return sheet.getRange(1, 1, lastRow, lastCol).getValues();
+}


### PR DESCRIPTION
### Motivation
- Split the existing Apps Script codebase into focused modules to improve maintainability and make functions easier to locate and reuse.
- Group the ingestion, categorization, sheet helpers, and alerting logic into their most relevant places to match the intended responsibilities.
- Keep a small `app` entrypoint that re-exports the main runtime entrypoints used by triggers and the UI.
- Preserve shared helpers and configuration as centralized modules for consistent access across the codebase.

### Description
- Added a new `src/` layout and TypeScript-style modules: `config.ts`, `core.ts`, `alerts.ts`, `sheets.ts`, `ingestion.ts`, `categorization.ts`, and `app.ts`.
- Moved ingestion-related functions into `src/ingestion.ts` including `ingestCSVs`, `mapRowToRecord` (as `mapRowToRecord`), `buildRowFromRecord`, `computeHeaderHash`, and `archiveFileIfConfigured`.
- Implemented categorization functions in `src/categorization.ts` (`applyCategorization`, `loadRules`, `onEdit`) and sheet helpers in `src/sheets.ts` (`ensureSheetWithHeaders`, `ensureHeaders`, `ensureColumn`, `buildExistingKeys`, `createHeaderIndex`, `rowToRecord`).
- Added alert utilities in `src/alerts.ts` (`sendAlert`, `getAlertEmail`, `getRequiredProperty`), a small `src/core.ts` for common helpers, and `src/app.ts` to re-export `ingestCSVs`, `applyCategorization`, and `onEdit`.

### Testing
- No automated tests were executed as part of this change.
- Existing test harness (under `tests/`) was not modified and remains available for local execution with `npm test` or the repository's test runner.
- Manual linting/compilation was not run in this rollout.
- Runtime behavior should be validated in the Apps Script environment and by running the existing unit tests locally against the sandboxed test loader.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960516316e8832ba5dd1c8397964f5f)