### PR TITLE
Add Config sheet for runtime settings

### DIFF
--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_ALERT_SUBJECT } from "./config";
+import { getConfigValue } from "./configSheet";
 
-const ALERT_EMAIL_PROPERTY = "ALERT_EMAIL";
+const ALERT_EMAIL_KEY = "ALERT_EMAIL";
 
 export function sendAlert(title: string, details: string): void {
   const to = getAlertEmail();
@@ -11,8 +12,5 @@ export function sendAlert(title: string, details: string): void {
 }
 
 export function getAlertEmail(): string {
-  const property = PropertiesService.getScriptProperties().getProperty(ALERT_EMAIL_PROPERTY);
-  if (property) return property;
-  const user = Session.getEffectiveUser();
-  return user ? user.getEmail() : "";
+  return getConfigValue(ALERT_EMAIL_KEY);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 export const SHEETS = {
   transactions: "Transactions",
-  rules: "Rules"
+  rules: "Rules",
+  config: "Config"
 };
 
 export const TARGET_SCHEMA = [

--- a/src/configSheet.ts
+++ b/src/configSheet.ts
@@ -1,0 +1,37 @@
+import { SHEETS } from "./config";
+import { ensureSheetWithHeaders } from "./sheets";
+
+const CONFIG_HEADERS = ["Key", "Value"];
+
+function getConfigSheet(): GoogleAppsScript.Spreadsheet.Sheet {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  return ensureSheetWithHeaders(spreadsheet, SHEETS.config, CONFIG_HEADERS);
+}
+
+function readConfigMap(): Record<string, string> {
+  const sheet = getConfigSheet();
+  const data = sheet.getDataRange().getValues();
+  if (data.length <= 1) return {};
+
+  const config: Record<string, string> = {};
+  for (let i = 1; i < data.length; i += 1) {
+    const key = String(data[i][0] ?? "").trim();
+    if (!key) continue;
+    const value = String(data[i][1] ?? "").trim();
+    config[key] = value;
+  }
+  return config;
+}
+
+export function getConfigValue(key: string): string {
+  const config = readConfigMap();
+  return config[key] ?? "";
+}
+
+export function getRequiredConfigValue(key: string): string {
+  const value = getConfigValue(key);
+  if (!value) {
+    throw new Error(`Missing required config value "${key}" in sheet "${SHEETS.config}".`);
+  }
+  return value;
+}

--- a/src/ingestion.ts
+++ b/src/ingestion.ts
@@ -2,20 +2,20 @@ import { CONFIGS_BY_HEADER_HASH, SHEETS, TARGET_SCHEMA } from "./config";
 import { normalizeHeaders } from "./core";
 import { sendAlert } from "./alerts";
 import { buildRowsFromCsvData, computeHeaderHash } from "./ingestionTransform";
-import { getRequiredProperty } from "./properties";
+import { getConfigValue, getRequiredConfigValue } from "./configSheet";
 import {
   buildExistingKeys,
   createHeaderIndex,
   ensureSheetWithHeaders
 } from "./sheets";
 
-const SCRIPT_PROPERTIES = {
+const CONFIG_KEYS = {
   rawFolderId: "RAW_FOLDER_ID",
   archiveFolderId: "ARCHIVE_FOLDER_ID"
 };
 
 export function ingestCSVs(): void {
-  const rawFolderId = getRequiredProperty(SCRIPT_PROPERTIES.rawFolderId);
+  const rawFolderId = getRequiredConfigValue(CONFIG_KEYS.rawFolderId);
   const folder = DriveApp.getFolderById(rawFolderId);
   const files = folder.getFiles();
   const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
@@ -83,9 +83,7 @@ export function ingestCSVs(): void {
 }
 
 function archiveFileIfConfigured(file: GoogleAppsScript.Drive.File): void {
-  const archiveFolderId = PropertiesService.getScriptProperties().getProperty(
-    SCRIPT_PROPERTIES.archiveFolderId
-  );
+  const archiveFolderId = getConfigValue(CONFIG_KEYS.archiveFolderId);
   if (!archiveFolderId) return;
   const archiveFolder = DriveApp.getFolderById(archiveFolderId);
   archiveFolder.addFile(file);


### PR DESCRIPTION
### Motivation
- Centralize runtime key/value settings in a single spreadsheet sheet to improve visibility and reduce duplication across sheet/code/script properties.
- Replace scattered lookups (script properties and implicit fallbacks) with an explicit, editable `Config` sheet.
- Make ingestion and alert behavior driven by spreadsheet-configurable values for easier ops.
- Provide helpers to read required and optional config values at runtime via `getConfigValue` and `getRequiredConfigValue`.

### Description
- Add `src/configSheet.ts` which ensures a `Config` sheet with `Key/Value` headers and exposes `getConfigValue` and `getRequiredConfigValue` to read settings.
- Register the `Config` sheet name in `SHEETS` by adding `SHEETS.config` in `src/config.ts`.
- Update `src/alerts.ts` to get the alert recipient from the config sheet via `getConfigValue("ALERT_EMAIL")` instead of script properties or session fallback.
- Update `src/ingestion.ts` to read `RAW_FOLDER_ID` (required) and `ARCHIVE_FOLDER_ID` (optional) from the config sheet via `getRequiredConfigValue`/`getConfigValue` and remove reliance on script properties.

### Testing
- No automated tests were run for these changes.
- Basic static checks performed during development (TypeScript compile/errors) were used informally and passed.
- Manual verification is recommended to ensure the `Config` sheet is created and keys like `RAW_FOLDER_ID` and `ALERT_EMAIL` are present.
- Runtime behavior should be validated in a staging spreadsheet before production rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69606774c38c832bb5e2d4fb6d4c070f)