### PR TITLE
Add HEADER_KEYS constant and use it for sheet mapping

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,22 @@ export const TARGET_SCHEMA = [
   "Matched Rule ID"
 ];
 
+export const HEADER_KEYS = {
+  accountName: "account name",
+  institution: "institution",
+  date: "date",
+  type: "type",
+  description: "description",
+  withdrawal: "withdrawal",
+  deposit: "deposit",
+  checkNumber: "check number",
+  category: "category",
+  sourceFile: "source file",
+  manualCategory: "manual category",
+  categoryByRule: "category by rule",
+  matchedRuleId: "matched rule id"
+};
+
 export const RULES_HEADERS = [
   "Rule ID",
   "ON",

--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -1,5 +1,6 @@
 import { generateCompositeKey, normalizeHeader } from "./core";
 import { parseNumber } from "./parsing";
+import { HEADER_KEYS } from "./config";
 import type { TransactionRecord } from "./core";
 
 export function ensureSheetWithHeaders(
@@ -83,41 +84,77 @@ export function createHeaderIndex(headers: string[]): Record<string, number> {
   return index;
 }
 
+export function ensureHeaderIndexContains(
+  headerIndex: Record<string, number>,
+  requiredHeaders: string[]
+): void {
+  const missing = requiredHeaders.filter((header) => headerIndex[header] === undefined);
+  if (missing.length > 0) {
+    throw new Error(`Missing header(s): ${missing.join(", ")}`);
+  }
+}
+
 export function buildRowFromRecord(
   record: TransactionRecord,
   headers: string[],
   headerIndex: Record<string, number>
 ): unknown[] {
   const row = new Array(headers.length).fill("");
-  row[headerIndex["account name"]] = record.accountName;
-  row[headerIndex["institution"]] = record.institution;
-  row[headerIndex["date"]] = record.date;
-  row[headerIndex["type"]] = record.type;
-  row[headerIndex["description"]] = record.description;
-  row[headerIndex["withdrawal"]] = record.withdrawal;
-  row[headerIndex["deposit"]] = record.deposit;
-  row[headerIndex["check number"]] = record.checkNumber;
-  row[headerIndex["category"]] = record.category;
-  row[headerIndex["source file"]] = record.sourceFile;
-  row[headerIndex["manual category"]] = record.manualCategory;
+  ensureHeaderIndexContains(headerIndex, [
+    HEADER_KEYS.accountName,
+    HEADER_KEYS.institution,
+    HEADER_KEYS.date,
+    HEADER_KEYS.type,
+    HEADER_KEYS.description,
+    HEADER_KEYS.withdrawal,
+    HEADER_KEYS.deposit,
+    HEADER_KEYS.checkNumber,
+    HEADER_KEYS.category,
+    HEADER_KEYS.sourceFile,
+    HEADER_KEYS.manualCategory
+  ]);
+  row[headerIndex[HEADER_KEYS.accountName]] = record.accountName;
+  row[headerIndex[HEADER_KEYS.institution]] = record.institution;
+  row[headerIndex[HEADER_KEYS.date]] = record.date;
+  row[headerIndex[HEADER_KEYS.type]] = record.type;
+  row[headerIndex[HEADER_KEYS.description]] = record.description;
+  row[headerIndex[HEADER_KEYS.withdrawal]] = record.withdrawal;
+  row[headerIndex[HEADER_KEYS.deposit]] = record.deposit;
+  row[headerIndex[HEADER_KEYS.checkNumber]] = record.checkNumber;
+  row[headerIndex[HEADER_KEYS.category]] = record.category;
+  row[headerIndex[HEADER_KEYS.sourceFile]] = record.sourceFile;
+  row[headerIndex[HEADER_KEYS.manualCategory]] = record.manualCategory;
   return row;
 }
 
 export function rowToRecord(row: unknown[], headerIndex: Record<string, number>): TransactionRecord {
+  ensureHeaderIndexContains(headerIndex, [
+    HEADER_KEYS.accountName,
+    HEADER_KEYS.institution,
+    HEADER_KEYS.date,
+    HEADER_KEYS.type,
+    HEADER_KEYS.description,
+    HEADER_KEYS.withdrawal,
+    HEADER_KEYS.deposit,
+    HEADER_KEYS.checkNumber,
+    HEADER_KEYS.category,
+    HEADER_KEYS.sourceFile,
+    HEADER_KEYS.manualCategory
+  ]);
   const getValue = (name: string) => String(row[headerIndex[name]] ?? "");
   const toNumber = (name: string) => parseNumber(row[headerIndex[name]]) ?? 0;
 
   return {
-    accountName: getValue("account name"),
-    institution: getValue("institution"),
-    date: getValue("date"),
-    type: getValue("type"),
-    description: getValue("description"),
-    withdrawal: toNumber("withdrawal"),
-    deposit: toNumber("deposit"),
-    checkNumber: getValue("check number"),
-    category: getValue("category"),
-    sourceFile: getValue("source file"),
-    manualCategory: getValue("manual category")
+    accountName: getValue(HEADER_KEYS.accountName),
+    institution: getValue(HEADER_KEYS.institution),
+    date: getValue(HEADER_KEYS.date),
+    type: getValue(HEADER_KEYS.type),
+    description: getValue(HEADER_KEYS.description),
+    withdrawal: toNumber(HEADER_KEYS.withdrawal),
+    deposit: toNumber(HEADER_KEYS.deposit),
+    checkNumber: getValue(HEADER_KEYS.checkNumber),
+    category: getValue(HEADER_KEYS.category),
+    sourceFile: getValue(HEADER_KEYS.sourceFile),
+    manualCategory: getValue(HEADER_KEYS.manualCategory)
   };
 }


### PR DESCRIPTION
### Motivation
- Centralize the canonical normalized header strings to avoid scattered string literals across the codebase.
- Improve defensive clarity when mapping between sheet rows and `TransactionRecord` objects by validating header presence.

### Description
- Add `HEADER_KEYS` mapping in `src/config.ts` with normalized header keys such as `accountName`, `date`, `withdrawal`, and `manualCategory`.
- Add `ensureHeaderIndexContains` helper in `src/sheets.ts` to assert required headers exist in a `headerIndex`.
- Replace literal header string usage in `buildRowFromRecord` and `rowToRecord` with `HEADER_KEYS` lookups and invoke the new helper before mapping.
- Update imports and adjust mapping logic so both read and write row functions use the centralized constants.

### Testing
- No automated tests were run against the modified code.
- Existing test suite was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607a904820832ba13de002c01f9471)