### PR TITLE
Prepare CSV config indices for ingestion

### DIFF
--- a/src/ingestion.ts
+++ b/src/ingestion.ts
@@ -1,7 +1,7 @@
 import { CONFIGS_BY_HEADER_HASH, SHEETS, TARGET_SCHEMA } from "./config";
 import { normalizeHeaders } from "./core";
 import { sendAlert } from "./alerts";
-import { buildRowsFromCsvData, computeHeaderHash } from "./ingestionTransform";
+import { buildRowsFromCsvData, computeHeaderHash, prepareCsvConfig } from "./ingestionTransform";
 import { getConfigValue, getRequiredConfigValue } from "./configSheet";
 import {
   buildExistingKeys,
@@ -54,10 +54,10 @@ export function ingestCSVs(): void {
       }
 
       const sourceIndex = createHeaderIndex(rawHeaders);
+      const preparedConfig = prepareCsvConfig(config, sourceIndex);
       const { rowsToAppend: newRows, updatedKeys } = buildRowsFromCsvData({
         csvData,
-        sourceIndex,
-        config,
+        config: preparedConfig,
         sourceFile: name,
         now,
         timeZone,


### PR DESCRIPTION
### Motivation
- Reduce per-row overhead by precomputing header-to-index mappings instead of normalizing and looking up headers for every row.
- Simplify `mapRowToRecord` to use direct numeric indices for column access.
- Centralize amount/withdrawal/deposit column index computation to avoid repeated lookups and normalization.
- Add explicit test coverage for the new prepared-config path.

### Description
- Add `PreparedCsvConfig` type that extends `CsvConfig` with `columnMapIndex` and optional `amountColumnIndex`, `withdrawalColumnIndex`, and `depositColumnIndex`.
- Add `prepareCsvConfig(config, sourceIndex)` helper which builds `columnMapIndex` (target header -> source index) and precomputes amount/withdrawal/deposit indices.
- Update `ingestion.ts` to call `prepareCsvConfig` after building `sourceIndex` and pass the prepared config into `buildRowsFromCsvData`.
- Update `mapRowToRecord` and `buildRowsFromCsvData` to accept `PreparedCsvConfig` and use the precomputed indices, removing per-row header normalization and lookups.
- Update tests in `tests/ingestionTransform.test.ts` to exercise `prepareCsvConfig` and to use the prepared config when calling `mapRowToRecord` and `buildRowsFromCsvData`.

### Testing
- Unit tests in `tests/ingestionTransform.test.ts` were updated to validate `prepareCsvConfig` and the prepared-config code path.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607aeebcd8832bbb6113540e57b41d)