### PR TITLE
Fix jest types and duplicate handling

### DIFF
--- a/src/ingestionTransform.ts
+++ b/src/ingestionTransform.ts
@@ -124,7 +124,7 @@ export function buildRowsFromCsvData(params: {
       type: record.type
     });
 
-    if (updatedKeys.has(key)) continue;
+    if (existingKeys.has(key)) continue;
     if (seenKeysInFile.has(key)) {
       record.description = `[Possible Duplicate] ${record.description}`;
     }

--- a/tests/ingestionTransform.test.ts
+++ b/tests/ingestionTransform.test.ts
@@ -1,5 +1,6 @@
 import { generateCompositeKey } from "../src/core";
 import { buildRowsFromCsvData, mapRowToRecord } from "../src/ingestionTransform";
+import type { CsvConfig } from "../src/ingestionTransform";
 import { TARGET_SCHEMA } from "../src/config";
 import { createHeaderIndex } from "../src/sheets";
 
@@ -7,7 +8,7 @@ describe("mapRowToRecord", () => {
   it("maps amounts using positive_deposit convention", () => {
     const headers = ["Date", "Description", "Amount"];
     const sourceIndex = createHeaderIndex(headers);
-    const config = {
+    const config: CsvConfig = {
       dateFormat: "yyyy-MM-dd",
       amountColumn: "Amount",
       signConvention: "positive_deposit",
@@ -31,7 +32,7 @@ describe("mapRowToRecord", () => {
   it("maps amounts using positive_withdrawal convention", () => {
     const headers = ["Date", "Description", "Amount"];
     const sourceIndex = createHeaderIndex(headers);
-    const config = {
+    const config: CsvConfig = {
       dateFormat: "yyyy-MM-dd",
       amountColumn: "Amount",
       signConvention: "positive_withdrawal",
@@ -60,7 +61,7 @@ describe("buildRowsFromCsvData", () => {
       ["2024-01-05", "Coffee", "-5.00"]
     ];
     const sourceIndex = createHeaderIndex(csvData[0] as string[]);
-    const config = {
+    const config: CsvConfig = {
       dateFormat: "yyyy-MM-dd",
       amountColumn: "Amount",
       signConvention: "positive_deposit",
@@ -94,7 +95,7 @@ describe("buildRowsFromCsvData", () => {
       ["2024-01-05", "Coffee", "-5.00"]
     ];
     const sourceIndex = createHeaderIndex(csvData[0] as string[]);
-    const config = {
+    const config: CsvConfig = {
       dateFormat: "yyyy-MM-dd",
       amountColumn: "Amount",
       signConvention: "positive_deposit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["google-apps-script"],
+    "types": ["google-apps-script", "jest"],
     "declaration": false
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],


### PR DESCRIPTION
### Motivation
- Enable TypeScript to recognize Jest test globals so tests compile cleanly under `strict` settings.
- Make test fixtures conform to the `CsvConfig` type to satisfy the stricter type-checking for sign conventions.
- Ensure intra-file duplicate CSV rows are flagged rather than silently skipped while still ignoring rows that already exist in the target sheet.

### Description
- Added `jest` to the `types` array in `tsconfig.json` to provide Jest typings for test files.
- Updated `tests/ingestionTransform.test.ts` to `import type { CsvConfig }` and annotate `config` fixtures as `CsvConfig`.
- Changed duplicate-check logic in `buildRowsFromCsvData` to use `existingKeys.has(key)` so only pre-existing keys are skipped and file-local duplicates are marked with `[Possible Duplicate]`.
- All other behavior is preserved and `buildRowsFromCsvData` still returns the accumulated `updatedKeys` set.

### Testing
- Ran the test suite with `npm test`.
- All test suites passed: `3 passed, 3 total` and all tests succeeded: `21 passed, 21 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960789dfae0832b872f8a24380c8b40)