### PR TITLE
Add unit test covering missing mapped CSV headers and extra columns

### DIFF
--- a/tests/ingestionTransform.test.ts
+++ b/tests/ingestionTransform.test.ts
@@ -81,6 +81,38 @@ describe("mapRowToRecord", () => {
     expect(record.withdrawal).toBe(0);
     expect(record.deposit).toBe(20);
   });
+
+  it("uses empty strings for missing mapped headers and ignores extra columns", () => {
+    const csvData = [
+      ["Date", "Amount", "Extra Column"],
+      ["2024-02-10", "-15.00", "ignored value"]
+    ];
+    const sourceIndex = createHeaderIndex(csvData[0] as string[]);
+    const config: CsvConfig = {
+      dateFormat: "yyyy-MM-dd",
+      amountColumn: "Amount",
+      signConvention: "positive_deposit",
+      columnMap: {
+        Date: "Date",
+        Description: "Description"
+      }
+    };
+
+    const prepared = prepareCsvConfig(config, sourceIndex);
+
+    const record = mapRowToRecord(
+      csvData[1],
+      prepared,
+      "file.csv",
+      new Date("2024-02-11T00:00:00Z"),
+      "UTC"
+    );
+
+    expect(record.description).toBe("");
+    expect(record.date).toBe("2024-02-10");
+    expect(record.withdrawal).toBe(15);
+    expect(record.category).toBe("");
+  });
 });
 
 describe("buildRowsFromCsvData", () => {


### PR DESCRIPTION
### Motivation

- Ensure missing source headers referenced in `columnMap` do not produce `undefined` values and instead resolve to empty strings.
- Verify that extra CSV columns not referenced by `columnMap` are ignored and do not affect the produced `TransactionRecord`.
- Increase coverage for the interaction between `prepareCsvConfig` and `mapRowToRecord` when a mapped header is absent.

### Description

- Add a new unit test `uses empty strings for missing mapped headers and ignores extra columns` to `tests/ingestionTransform.test.ts`.
- The test builds `csvData` with headers `["Date", "Amount", "Extra Column"]`, prepares a config that maps `Description` (which is missing), calls `prepareCsvConfig` and `mapRowToRecord`, and asserts that `record.description` is `""`, `record.date` is `"2024-02-10"`, `record.withdrawal` is `15`, and `record.category` is `""`.
- Commit updates to `tests/ingestionTransform.test.ts` to add this coverage.

### Testing

- No automated test suite (`jest`) was executed as part of this change.
- The new unit test was added to the repository but has not been run locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696116defd48832b89001a93f88470ca)