### PR TITLE
Add mapRowToRecord tests for withdrawal/deposit columns

### DIFF
--- a/tests/ingestionTransform.test.ts
+++ b/tests/ingestionTransform.test.ts
@@ -81,6 +81,58 @@ describe("mapRowToRecord", () => {
     expect(record.withdrawal).toBe(0);
     expect(record.deposit).toBe(20);
   });
+
+  it("maps withdrawal and deposit columns when both are present", () => {
+    const headers = ["Date", "Description", "Withdrawal", "Deposit"];
+    const sourceIndex = createHeaderIndex(headers);
+    const config: CsvConfig = {
+      dateFormat: "yyyy-MM-dd",
+      withdrawalColumn: "Withdrawal",
+      depositColumn: "Deposit",
+      signConvention: "positive_deposit",
+      columnMap: {
+        Date: "Date",
+        Description: "Description"
+      }
+    };
+
+    const prepared = prepareCsvConfig(config, sourceIndex);
+
+    const record = mapRowToRecord([
+      "2024-02-10",
+      "Payroll",
+      "45.25",
+      "1500.00"
+    ], prepared, "file.csv", new Date("2024-02-11T00:00:00Z"), "UTC");
+
+    expect(record.withdrawal).toBe(45.25);
+    expect(record.deposit).toBe(1500);
+  });
+
+  it("defaults missing withdrawal/deposit columns to zero", () => {
+    const headers = ["Date", "Description", "Withdrawal"];
+    const sourceIndex = createHeaderIndex(headers);
+    const config: CsvConfig = {
+      dateFormat: "yyyy-MM-dd",
+      withdrawalColumn: "Withdrawal",
+      signConvention: "positive_deposit",
+      columnMap: {
+        Date: "Date",
+        Description: "Description"
+      }
+    };
+
+    const prepared = prepareCsvConfig(config, sourceIndex);
+
+    const record = mapRowToRecord([
+      "2024-02-12",
+      "ATM",
+      "80.00"
+    ], prepared, "file.csv", new Date("2024-02-13T00:00:00Z"), "UTC");
+
+    expect(record.withdrawal).toBe(80);
+    expect(record.deposit).toBe(0);
+  });
 });
 
 describe("buildRowsFromCsvData", () => {

--- a/tests/ingestionTransform.test.ts
+++ b/tests/ingestionTransform.test.ts
@@ -109,49 +109,54 @@ describe("mapRowToRecord", () => {
     expect(record.deposit).toBe(1500);
   });
 
-  it("defaults missing withdrawal/deposit columns to zero", () => {
-    const cases = [
-      {
-        headers: ["Date", "Description", "Withdrawal"],
-        config: {
-          withdrawalColumn: "Withdrawal"
-        },
-        row: ["2024-02-12", "ATM", "80.00"],
-        expected: { withdrawal: 80, deposit: 0 }
-      },
-      {
-        headers: ["Date", "Description", "Deposit"],
-        config: {
-          depositColumn: "Deposit"
-        },
-        row: ["2024-02-12", "Interest", "12.34"],
-        expected: { withdrawal: 0, deposit: 12.34 }
+  it("defaults deposit to zero when only withdrawal is present", () => {
+    const headers = ["Date", "Description", "Withdrawal"];
+    const sourceIndex = createHeaderIndex(headers);
+    const prepared = prepareCsvConfig({
+      dateFormat: "yyyy-MM-dd",
+      withdrawalColumn: "Withdrawal",
+      signConvention: "positive_deposit",
+      columnMap: {
+        Date: "Date",
+        Description: "Description"
       }
-    ];
+    }, sourceIndex);
 
-    cases.forEach(({ headers, config, row, expected }) => {
-      const sourceIndex = createHeaderIndex(headers);
-      const prepared = prepareCsvConfig({
-        dateFormat: "yyyy-MM-dd",
-        signConvention: "positive_deposit",
-        columnMap: {
-          Date: "Date",
-          Description: "Description"
-        },
-        ...config
-      }, sourceIndex);
+    const record = mapRowToRecord(
+      ["2024-02-12", "ATM", "80.00"],
+      prepared,
+      "file.csv",
+      new Date("2024-02-13T00:00:00Z"),
+      "UTC"
+    );
 
-      const record = mapRowToRecord(
-        row,
-        prepared,
-        "file.csv",
-        new Date("2024-02-13T00:00:00Z"),
-        "UTC"
-      );
+    expect(record.withdrawal).toBe(80);
+    expect(record.deposit).toBe(0);
+  });
 
-      expect(record.withdrawal).toBe(expected.withdrawal);
-      expect(record.deposit).toBe(expected.deposit);
-    });
+  it("defaults withdrawal to zero when only deposit is present", () => {
+    const headers = ["Date", "Description", "Deposit"];
+    const sourceIndex = createHeaderIndex(headers);
+    const prepared = prepareCsvConfig({
+      dateFormat: "yyyy-MM-dd",
+      depositColumn: "Deposit",
+      signConvention: "positive_deposit",
+      columnMap: {
+        Date: "Date",
+        Description: "Description"
+      }
+    }, sourceIndex);
+
+    const record = mapRowToRecord(
+      ["2024-02-12", "Interest", "12.34"],
+      prepared,
+      "file.csv",
+      new Date("2024-02-13T00:00:00Z"),
+      "UTC"
+    );
+
+    expect(record.withdrawal).toBe(0);
+    expect(record.deposit).toBe(12.34);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Ensure `mapRowToRecord` handles CSVs that provide separate withdrawal and deposit columns instead of a single `amount` column.
- Verify numeric parsing works when both `withdrawalColumn` and `depositColumn` are present.
- Confirm the code defaults a missing counterpart column to `0` when only one of `withdrawalColumn` or `depositColumn` is supplied.

### Description
- Added tests in `tests/ingestionTransform.test.ts` under the `mapRowToRecord` suite to cover split columns handling.
- Added a test that builds headers `["Date","Description","Withdrawal","Deposit"]` and verifies `withdrawal` and `deposit` are parsed from the provided CSV row via `prepareCsvConfig` and `mapRowToRecord`.
- Added a test that uses only a `Withdrawal` column and verifies `deposit` defaults to `0` when mapping the row.

### Testing
- Unit tests were added to the test suite (`tests/ingestionTransform.test.ts`).
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611743ff4c832bb9189c3597265cb2)