### PR TITLE
Refresh documentation, add README generator, and file header comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ This project provides a spreadsheet-native ETL for ingesting bank CSV exports in
 - `tests/` – Jest tests for pure helper utilities.
 - `dist/` – Compiled Apps Script (generated).
 
+## Architecture
+
+```mermaid
+flowchart TD
+  A[Drive CSVs] -->|ingestCSVs| B[ingestion.ts]
+  B --> C[parsing.ts]
+  B --> D[ingestionTransform.ts]
+  D --> E[sheets.ts]
+  D --> F[core.ts]
+  E --> G[Transactions Sheet]
+  H[Rules Sheet] --> I[categorization.ts]
+  I --> G
+  J[Triggers & entrypoints] --> K[app.ts]
+  K -->|onEdit| I
+  K -->|manual runs| B
+  L[Config lookup] --> M[config.ts]
+  M --> B
+  M --> I
+  N[Alerts] --> O[alerts.ts]
+  B --> O
+```
+
 ## Setup
 
 1. Install dependencies:
@@ -48,11 +70,36 @@ npm run push
 
 ## Sheets expected
 
-### Transactions sheet
-A `Transactions` sheet with at least the headers defined in `TARGET_SCHEMA` (extra columns are preserved).
+Run `npm run docs:readme` to refresh the lists below from `src/config.ts`.
 
-### Rules sheet
-A `Rules` sheet with headers defined in `RULES_HEADERS` in `src/config.ts`.
+<!-- CONFIG_HEADERS_START -->
+### Transactions sheet headers
+
+- `Account Name`
+- `Institution`
+- `Date`
+- `Type`
+- `Description`
+- `Withdrawal`
+- `Deposit`
+- `Check Number`
+- `Category`
+- `Source File`
+- `Manual Category`
+- `Category by Rule`
+- `Matched Rule ID`
+
+### Rules sheet headers
+
+- `Rule ID`
+- `ON`
+- `Category`
+- `Description Regex`
+- `Account Regex`
+- `Type Regex`
+- `Min Amount`
+- `Max Amount`
+<!-- CONFIG_HEADERS_END -->
 
 ## Notes
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+// Jest configuration for the TypeScript test suite.
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "//": "Unset http-proxy/https-proxy during tests to avoid npm's unknown env config warning.",
   "scripts": {
     "build": "tsc",
+    "docs:readme": "node scripts/update-readme.js",
     "test": "env -u http-proxy -u https-proxy jest",
     "push": "npm run build && clasp push"
   },

--- a/scripts/update-readme.js
+++ b/scripts/update-readme.js
@@ -1,0 +1,53 @@
+// Generates README sections that mirror the sheet headers defined in src/config.ts.
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const configPath = path.join(repoRoot, "src", "config.ts");
+const readmePath = path.join(repoRoot, "README.md");
+
+const START_MARKER = "<!-- CONFIG_HEADERS_START -->";
+const END_MARKER = "<!-- CONFIG_HEADERS_END -->";
+
+const readText = (filePath) => fs.readFileSync(filePath, "utf8");
+
+const extractArray = (source, name) => {
+  const regex = new RegExp(`export const ${name} = \\[(.*?)\\];`, "s");
+  const match = source.match(regex);
+  if (!match) {
+    throw new Error(`Unable to find ${name} in ${configPath}`);
+  }
+  return Array.from(match[1].matchAll(/"([^"]+)"/g)).map((item) => item[1]);
+};
+
+const renderList = (items) => items.map((item) => `- \`${item}\``).join("\n");
+
+const renderSection = (targetHeaders, rulesHeaders) => [
+  "### Transactions sheet headers",
+  "",
+  renderList(targetHeaders),
+  "",
+  "### Rules sheet headers",
+  "",
+  renderList(rulesHeaders)
+].join("\n");
+
+const replaceSection = (readme, replacement) => {
+  const startIndex = readme.indexOf(START_MARKER);
+  const endIndex = readme.indexOf(END_MARKER);
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error("README markers missing or out of order.");
+  }
+  const before = readme.slice(0, startIndex + START_MARKER.length);
+  const after = readme.slice(endIndex);
+  return `${before}\n${replacement}\n${after}`;
+};
+
+const configSource = readText(configPath);
+const targetHeaders = extractArray(configSource, "TARGET_SCHEMA");
+const rulesHeaders = extractArray(configSource, "RULES_HEADERS");
+const readmeSource = readText(readmePath);
+const updatedReadme = replaceSection(readmeSource, renderSection(targetHeaders, rulesHeaders));
+
+fs.writeFileSync(readmePath, updatedReadme);
+console.log("README header section updated.");

--- a/src/alerts.ts
+++ b/src/alerts.ts
@@ -1,3 +1,4 @@
+// Alert email helpers for ingestion failures and configuration warnings.
 import { DEFAULT_ALERT_SUBJECT } from "./config";
 import { getConfigValue } from "./configSheet";
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+// Apps Script entrypoints and trigger wiring for ingestion and categorization.
 import { applyCategorization, applyCategorizationForTransactionRows } from "./categorization";
 import { ingestCSVs } from "./ingestion";
 import { SHEETS } from "./config";

--- a/src/categorization.ts
+++ b/src/categorization.ts
@@ -1,3 +1,4 @@
+// Rule-based categorization for transactions using the Rules sheet.
 import { RULES_HEADERS, SHEETS, TARGET_SCHEMA } from "./config";
 import { ruleMatches } from "./core";
 import { buildRegex, parseNumber } from "./parsing";

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+// Shared configuration for sheet names, schemas, and source mappings.
 export const SHEETS = {
   transactions: "Transactions",
   rules: "Rules",

--- a/src/configSheet.ts
+++ b/src/configSheet.ts
@@ -1,3 +1,4 @@
+// Reads and validates key/value configuration stored in the Config sheet.
 import { SHEETS } from "./config";
 import { ensureSheetWithHeaders } from "./sheets";
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,3 +1,4 @@
+// Shared core types and helpers for normalization and rule matching.
 export type TransactionRecord = {
   accountName: string;
   institution: string;

--- a/src/ingestion.ts
+++ b/src/ingestion.ts
@@ -1,3 +1,4 @@
+// CSV ingestion pipeline that reads Drive files and appends normalized rows.
 import { CONFIGS_BY_HEADER_HASH, SHEETS, TARGET_SCHEMA } from "./config";
 import { normalizeHeaders } from "./core";
 import { sendAlert } from "./alerts";

--- a/src/ingestionTransform.ts
+++ b/src/ingestionTransform.ts
@@ -1,3 +1,4 @@
+// Transforms CSV rows into normalized transaction records and sheet rows.
 import { generateCompositeKey, normalizeHeader } from "./core";
 import { formatDateForSheet, parseCurrency, parseDate } from "./parsing";
 import { buildRowFromRecord, Table } from "./sheets";

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1,3 +1,4 @@
+// Parsing helpers for dates, currency, numbers, and rule regexes.
 export function parseDateFallback(value: string): Date | null {
   if (!value) return null;
   const fallback = new Date(value);

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -1,3 +1,4 @@
+// Helpers for accessing Apps Script properties with validation.
 export function getRequiredProperty(name: string): string {
   const value = PropertiesService.getScriptProperties().getProperty(name);
   if (!value) {

--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -1,3 +1,4 @@
+// Spreadsheet helpers for headers, table lookups, and row conversions.
 import { generateCompositeKey, normalizeHeader } from "./core";
 import { parseNumber } from "./parsing";
 import { HEADER_KEYS } from "./config";

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,3 +1,4 @@
+// Tests for core normalization helpers and rule matching.
 import { generateCompositeKey, normalizeHeader, normalizeHeaders, ruleMatches } from "../src/core";
 import type { Rule, TransactionRecord } from "../src/core";
 

--- a/tests/ingestionTransform.test.ts
+++ b/tests/ingestionTransform.test.ts
@@ -1,3 +1,4 @@
+// Tests for CSV ingestion transforms and record mapping.
 import { generateCompositeKey } from "../src/core";
 import { buildRowsFromCsvData, mapRowToRecord, prepareCsvConfig } from "../src/ingestionTransform";
 import type { CsvConfig } from "../src/ingestionTransform";

--- a/tests/parsing.test.ts
+++ b/tests/parsing.test.ts
@@ -1,3 +1,4 @@
+// Tests for parsing helpers used by ingestion and categorization.
 import { buildRegex, formatDateForSheet, parseCurrency, parseDate, parseNumber } from "../src/parsing";
 
 describe("parseCurrency", () => {


### PR DESCRIPTION
### Motivation

- Ensure the README stays accurate and can expose sheet header lists directly from the code configuration in `src/config.ts`.
- Make the repository easier for a new developer to orient by adding a simple architecture diagram in the README.
- Provide concise top-of-file gists so maintainers can quickly understand each module's responsibility.
- Add a small tooling script and npm helper to keep the README header lists synchronized with code.

### Description

- Add `scripts/update-readme.js` which extracts `TARGET_SCHEMA` and `RULES_HEADERS` from `src/config.ts` and replaces a marked section in `README.md` with generated header lists.
- Update `README.md` to include a `mermaid` architecture diagram and the `<!-- CONFIG_HEADERS_START -->`/`<!-- CONFIG_HEADERS_END -->` markers where generated lists are inserted.
- Add an npm script `docs:readme` to run the README generator and add short explanatory comments to `jest.config.js`.
- Insert concise top-of-file comments across multiple source files and tests (e.g. `src/*.ts`, `tests/*.test.ts`) to summarize each file's purpose.

### Testing

- No automated tests were executed as part of this change since it is documentation-focused.
- The change only modifies documentation and comments and does not alter runtime logic used by the test suite.
- The repository test configuration remains intact (`npm test` and `tsc` unchanged) and can be run normally after the update.
- Running `npm run docs:readme` regenerates the README header lists from `src/config.ts` (manual verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611c943a9c832b92c327d87b226427)